### PR TITLE
Ubuntu versions consistently standarised

### DIFF
--- a/static/js/publisher/metrics/tooltips.js
+++ b/static/js/publisher/metrics/tooltips.js
@@ -6,12 +6,16 @@ function commaNumber(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
+function standariseOSName(os) {
+  return os.replace('/',' ');
+}
+
 function generateSeriesMarkup(point, color, highlight) {
   let series = [];
   color = color || 'transparent';
   let extraClass = highlight === point.name ? ' is-hovered' : '';
   series.push(`<span class="snapcraft-graph-tooltip__series${extraClass}" title="${point.name}">`);
-  series.push(`<span class="snapcraft-graph-tooltip__series-name">${point.name}</span>`);
+  series.push(`<span class="snapcraft-graph-tooltip__series-name">${standariseOSName(point.name)}</span>`);
   series.push(`<span class="snapcraft-graph-tooltip__series-color" style="background:${color};"></span>`);
   series.push(`<span class="snapcraft-graph-tooltip__series-value">${commaNumber(point.value)}</span>`);
   series.push('</span>');


### PR DESCRIPTION
Right now on the public listing page we refer to different versions of ubuntu like "Ubuntu 18.04" whereas in the Metrics page within publisher pages, we refere OS versions as "Ubuntu/18.04".

The solution in this pull request is replace "/" with a space to make them look equal in both places